### PR TITLE
Gps fix

### DIFF
--- a/.github/workflows/sonarqube-analysis.yml
+++ b/.github/workflows/sonarqube-analysis.yml
@@ -23,14 +23,17 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
-      - name: Analyze with SonarCloud	
-
-        uses: SonarSource/sonarcloud-github-action@v5.0.0
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.3.0
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Needed to post analysis
         with:
           args:
-            # mandatory
             -Dsonar.projectKey=StrategFirst_BingWall
             -Dsonar.organization=strategfirst
+            -Dsonar.sources=scrap,web
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" style="text-align: center;">
 
-### 4.7.2
+### 4.7.4
 # BingWall
 
 

--- a/scrap/index.js
+++ b/scrap/index.js
@@ -19,6 +19,8 @@ class BingWallError extends Error {
  * Download from the given `webURL` a file and
  * write it to `localPath`
  * 
+ * Be aware that no header are injected for this !
+ * 
  * JSDoc :
  * 
  * @param {Document} webURL
@@ -56,7 +58,7 @@ async function get_GPS( origin_DOM, origin_HTML ) {
 		// Get the linked page :
 		let GPS_coord = await fetch(
 							`https://bing.com${location_path}`,
-							{headers: {'User-Agent': 'NodeJS'}}
+							{headers: {'User-Agent': 'Now/You See/Me2'}}
 						)
 						.then( res => res.text() )
 						.then( txt => parse(txt) )
@@ -157,7 +159,7 @@ async function TodayMetadata() {
 						// Grab the page content
 						const HTMLPage = await fetch(
 							`https://www.bing.com?cc=${country.code}`,
-							{headers: {'User-Agent': 'NodeJS'}}
+							{headers: {'User-Agent': 'Now/You See/Me2'}}
 						).then( res => res.text() );
 
 						// Use metadata finder :

--- a/scrap/package-lock.json
+++ b/scrap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botwallbing",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "botwallbing",
-      "version": "4.7.3",
+      "version": "4.7.4",
       "dependencies": {
         "node-html-parser": "^7.0.1"
       }

--- a/scrap/package.json
+++ b/scrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botwallbing",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "type": "module",
   "dependencies": {
     "node-html-parser": "^7.0.1"

--- a/web/scripts/loader.js
+++ b/web/scripts/loader.js
@@ -42,7 +42,12 @@ function toPanelDom( path, name ) {
     txt_dom += `<label class="neo-check" for="desc-link-details${ll=(window.toDescDomCount+=1)}"> <input type="checkbox" onchange="change_description(event)" id="desc-link-details${ll}" /> <div> <i class="local-icon">info</i>     </div> </label>`;
 
     if(md.gps != null) {
-        let titleCleans = [... md.titles.values()].filter( title => !(title.match(/^Info$/i)) )[0]
+        let titleCleans = [... md.titles.values()].filter( title => !(title.match(/^Info$/i)) )[0];
+        if( titleCleans == undefined ) {
+            titleCleans = 'Missing Clean Title';
+            console.warn('Missing clean title');
+            console.trace();
+        }
         let marker_ref_id = addMarker(
             md.gps.lat,
             md.gps.long,


### PR DESCRIPTION
# GPS Crawling Fix & Enhancements

## Fixes
 - Fixes GPS Crawling
 - Update SonarQube

## Explanation 

### GPS Crawler
Over time Bing is introducing further and further requirements for their page being fetched, probably to avoid bots & crawler like this one from basically crawling their data.
As a quick recap in history :
- At the beginning nothing was required, a simple query to the right path was enough (no headers no extras)
- Then `User-Agent` as non-empty was required, any value was accepted
- And today `User-Agent` must be closer to [the official format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent)

However, even [Mozilla official wiki say's that this is a bad thing to rely on.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Browser_detection_using_the_user_agent). We of course aren't giving a real config and continue trolling them a bit (see changes).

### SonarQube

Deprecation made old SonarCloud github action deprecated an update was required, this pull request was the right time to adjust and enhance a bit those, however this pull request won't the place were additional issues and code quality and hotspot will be fixed, this will require another PR.